### PR TITLE
Use notify prerelease

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ crossbeam-channel = "0.3.7"
 crossbeam-queue = "0.1.2"
 crossbeam-utils = "0.6.5"
 fern = { git = "https://github.com/itkovian/fern", branch = "reopen", features = ["reopen-03"]}
-#notify = "4.0.12"
-notify = { git = "https://github.com/passcod/notify", branch = "main" }
+notify = "=5.0.0-pre.0"
 libc = "0.2.58"
 log = "^0.4.6"
 reopen = "^0.3.0"


### PR DESCRIPTION
You probably want pre.0 instead of the main branch now, until debouncing is back! Also should mean you can publish to crates.io again soon (after a fern release if I'm reading correctly?), if that's useful to you.