### PR TITLE
Notify 5.0 - pre1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ crossbeam-channel = "0.3.7"
 crossbeam-queue = "0.1.2"
 crossbeam-utils = "0.6.5"
 fern = { git = "https://github.com/itkovian/fern", branch = "reopen", features = ["reopen-03"]}
-#notify = "4.0.12"
-notify = { git = "https://github.com/passcod/notify", branch = "main" }
+#notify = "5.0.0-pre.1"
+notify = { git = "https://github.com/passcod/notify", branch = "main", commit = "0709c94" }
 libc = "0.2.58"
 log = "^0.4.6"
 reopen = "^0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sarchive"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Andy Georges <itkovian@gmail.com>"]
 edition = "2018"
 description = "Archiving tool for slurm job scripts"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,13 +227,13 @@ pub fn monitor(
             recv(sigchannel) -> b => if let Ok(true) = b  {
                 return Ok(());
             },
-            recv(rx) -> event => { match event {
-                Ok(e) => check_and_queue(s, e.unwrap())?,
-                Err(e) => {
-                    error!("Error on received event: {:?}", e);
+            recv(rx) -> event => { 
+                if let Ok(Ok(e)) = event { check_and_queue(s, e)? }
+                else {
+                    error!("Error on received event: {:?}", event);
                     break;
                 }
-            };}
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,6 @@ use clap::{App, Arg};
 use crossbeam_channel::{bounded, unbounded};
 use crossbeam_utils::sync::Parker;
 use crossbeam_utils::thread::scope;
-use reopen::Reopen;
-use std::fs::{File, OpenOptions};
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::process::exit;
@@ -46,15 +44,6 @@ use std::sync::Arc;
 
 mod lib;
 use lib::{monitor, process, signal_handler_atomic, Period};
-
-#[inline]
-fn my_open<P: AsRef<Path>>(filename: P) -> Result<File, std::io::Error> {
-    OpenOptions::new()
-        .create(true)
-        .write(true)
-        .append(true)
-        .open(filename)
-}
 
 
 fn setup_logging(


### PR DESCRIPTION
Version 5.0 of https://github.com/passcod/notify removed the DebouncedEvent for now. 

- Adjust code to use the new Event and EventKind data structures
- In the actual archival code, make sure the event is not processed before 2s have elapsed since the job entry was created and queued after receiving the notification of the job dir creation. This should more or less act similar to the DebouncedEvent:
    - removals rarely happen
    - we only care about dir creation

Once both notify and fern have new crates, we can also push a new version to crates.io.

Use the fixed commit 0709c94 from notify, to ensure the new Events are used. The 5.0.0-pre.1 crate on crates.io is a bit older, and still has the RawEvents.