### PR TITLE
Modularise the current codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sarchive"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Andy Georges <itkovian@gmail.com>"]
 edition = "2018"
 description = "Archiving tool for slurm job scripts"

--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -27,8 +27,20 @@ use std::thread::sleep;
 
 use super::{Archive};
 use super::super::slurm::{SlurmJobEntry};
-use super::super::utils::{Period};
 
+/// An enum to define a hierachy in the archive
+pub enum Period {
+    /// Leads to a YYYYMMDD subdir
+    Daily,
+    /// Leads to a YYYYMM subdir
+    Monthly,
+    /// Leads to a YYYY subdir
+    Yearly,
+    /// No subdir
+    None,
+}
+
+/// An aerchiver that writes job script info to a file
 pub struct FileArchive {
     archive_path: PathBuf,
     period: Period,
@@ -42,7 +54,6 @@ impl FileArchive {
         }
     }
 }
-
 
 impl Archive for FileArchive {
     /// Archives the files from the given SlurmJobEntry's path.

--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -1,0 +1,237 @@
+/*
+Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+use std::fs::{copy, create_dir_all};
+use std::io::Error;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use std::thread::sleep;
+
+use super::{Archive};
+use super::super::slurm::{SlurmJobEntry};
+use super::super::utils::{Period};
+
+pub struct FileArchive {
+    archive_path: PathBuf,
+    period: Period,
+}
+
+impl FileArchive {
+    pub fn new(archive_path: &PathBuf, p: Period) -> Self {
+        FileArchive {
+            archive_path: archive_path.clone(),
+            period: p,
+        }
+    }
+}
+
+
+impl Archive for FileArchive {
+    /// Archives the files from the given SlurmJobEntry's path.
+    ///
+    /// We busy wait for 1 second, sleeping for 10 ms per turn for
+    /// the environment and script files to appear.
+    /// If the files cannot be found after that tine, we output a warning
+    /// and return without copying.
+    /// If the directory dissapears before we found or copied the files,
+    /// we panic.
+    fn archive(&self, slurm_job_entry: &SlurmJobEntry) -> Result<(), Error> {
+        // Simulate the debounced event we had before. Wait two seconds after dir creation event to
+        // have some assurance the files will have been written.
+        if slurm_job_entry.moment.elapsed().as_secs() < 2 {
+            sleep(Duration::from_millis(2000) - slurm_job_entry.moment.elapsed());
+        }
+        let ten_millis = Duration::from_millis(10);
+        // We wait for each file to be present
+
+        let archive_path = &self.archive_path;
+        let p = &self.period;
+        for filename in &["script", "environment"] {
+            let fpath = slurm_job_entry.path.join(filename);
+            let mut iters = 100;
+            while !Path::exists(&fpath) && iters > 0 {
+                debug!("Waiting for {:?}", fpath);
+                sleep(ten_millis);
+                if !Path::exists(&slurm_job_entry.path) {
+                    error!("Job directory {:?} no longer exists", &slurm_job_entry.path);
+                    panic!("path not found");
+                }
+                iters -= 1;
+            }
+            if iters == 0 {
+                warn!("Cannot make copy of {:?}", fpath);
+                continue;
+            }
+
+            let target_path = determine_target_path(&archive_path, &p, &slurm_job_entry, &filename);
+
+            match copy(&fpath, &target_path) {
+                Ok(bytes) => info!(
+                    "copied {} bytes from {:?} to {:?}",
+                    bytes, &fpath, &target_path
+                ),
+                Err(e) => {
+                    error!(
+                        "Copy of {:?} to {:?} failed: {:?}",
+                        &slurm_job_entry.path, &target_path, e
+                    );
+                    return Err(e);
+                }
+            };
+        }
+
+        Ok(())
+    }
+
+}
+
+/// Determines the target path for the slurm job file
+///
+/// The path will have the following components:
+/// - the archive path
+/// - a subdir depending on the Period
+///     - YYYY in case of a Yearly Period
+///     - YYYYMM in case of a Monthly Period
+///     - YYYYMMDD in case of a Daily Period
+/// - a file with the given filename
+fn determine_target_path(
+    archive_path: &Path,
+    p: &Period,
+    slurm_job_entry: &SlurmJobEntry,
+    filename: &str,
+) -> PathBuf {
+    let archive_subdir = match p {
+        Period::Yearly => Some(format!("{}", chrono::Local::now().format("%Y"))),
+        Period::Monthly => Some(format!("{}", chrono::Local::now().format("%Y%m"))),
+        Period::Daily => Some(format!("{}", chrono::Local::now().format("%Y%m%d"))),
+        _ => None,
+    };
+    debug!("Archive subdir is {:?}", &archive_subdir);
+    match archive_subdir {
+        Some(d) => {
+            let archive_subdir_path = archive_path.join(&d);
+            if !Path::exists(&archive_subdir_path) {
+                debug!("Archive subdir {:?} does not yet exist, creating", &d);
+                create_dir_all(&archive_subdir_path).unwrap();
+            }
+            archive_subdir_path
+                .clone()
+                .join(format!("job.{}_{}", &slurm_job_entry.jobid, &filename))
+        }
+        None => archive_path.join(format!("job.{}_{}", &slurm_job_entry.jobid, &filename)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    extern crate tempfile;
+
+    use super::*;
+    use std::fs::{create_dir, read_to_string, File};
+    use std::io::Write;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_is_job_path() {
+        let tdir = tempdir().unwrap();
+
+        // this should pass
+        let jobdir = tdir.path().join("job.1234");
+        let _dir = create_dir(&jobdir);
+        assert_eq!(is_job_path(&jobdir), Some(("1234", "job.1234")));
+
+        // this should fail
+        let fdir = tdir.path().join("fubar");
+        let _faildir = create_dir(&fdir);
+        assert_eq!(is_job_path(&fdir), None);
+    }
+
+    #[test]
+    fn test_determine_target_path() {
+        let tdir = tempdir().unwrap();
+
+        // create the basic archive path
+        let archive_dir = tdir.path();
+        let _dir = create_dir(&archive_dir);
+        let slurm_job_entry = slurm::SlurmJobEntry::new(&PathBuf::from("/tmp/some/job/path"), "1234");
+
+        let p = Period::None;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(format!("job.1234_foobar")));
+
+        let d = format!("{}", chrono::Local::now().format("%Y"));
+        let p = Period::Yearly;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(d).join("job.1234_foobar"));
+
+        let d = format!("{}", chrono::Local::now().format("%Y%m"));
+        let p = Period::Monthly;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(d).join("job.1234_foobar"));
+
+        let d = format!("{}", chrono::Local::now().format("%Y%m%d"));
+        let p = Period::Daily;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(d).join("job.1234_foobar"));
+    }
+
+    #[test]
+    fn test_archive() {
+        let tdir = tempdir().unwrap();
+
+        // create the basic archive path
+        let archive_dir = tdir.path().join("archive");
+        let _dir = create_dir(&archive_dir);
+
+        // create the basic job path
+        let job_dir = tdir.path().join("job.1234");
+        let _dir = create_dir(&job_dir);
+
+        // create env and script files
+        let env_path = job_dir.join("environment");
+        let mut env = File::create(env_path).unwrap();
+        env.write(b"environment");
+
+        let job_path = job_dir.join("script");
+        let mut job = File::create(&job_path).unwrap();
+        job.write(b"job script");
+
+        let slurm_job_entry = slurm::SlurmJobEntry::new(&job_dir, "1234");
+
+        archive(&archive_dir, &Period::None, &slurm_job_entry);
+
+        assert!(Path::is_file(&archive_dir.join("job.1234_environment")));
+        assert!(Path::is_file(&archive_dir.join("job.1234_script")));
+
+        let archive_env_contents =
+            read_to_string(&archive_dir.join("job.1234_environment")).unwrap();
+        assert_eq!(&archive_env_contents, "environment");
+
+        let archive_script_contents = read_to_string(&archive_dir.join("job.1234_script")).unwrap();
+        assert_eq!(&archive_script_contents, "job script");
+    }
+}

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+pub mod file;
+
+use std::io::Error;
+use super::slurm;
+
+/// The Archive trait should be implemented by every backend.
+pub trait Archive {
+    fn archive(&self, slurm_job_entry: &slurm::SlurmJobEntry) -> Result<(), Error>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,8 @@ mod archive;
 mod slurm;
 mod utils;
 
-use utils::{monitor, process, signal_handler_atomic, Period};
+use utils::{monitor, process, signal_handler_atomic};
+use archive::file::{FileArchive, Period};
 
 
 fn setup_logging(
@@ -213,7 +214,7 @@ fn main() {
     let (sig_sender, sig_receiver) = bounded(20);
 
     let cleanup = matches.is_present("cleanup");
-    let file_archiver = archive::file::FileArchive::new(&archive.to_path_buf(), period);
+    let file_archiver = FileArchive::new(&archive.to_path_buf(), period);
 
     // we will watch the ten hash.X directories
     let (sender, receiver) = unbounded();

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,6 @@ extern crate chrono;
 extern crate clap;
 extern crate crossbeam_channel;
 extern crate crossbeam_utils;
-extern crate elastic;
-#[macro_use] extern crate elastic_derive;
 extern crate fern;
 extern crate libc;
 #[macro_use] extern crate log;

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// Representation of an entry in the Slurm job spool hash directories
+pub struct SlurmJobEntry {
+    /// The full path to the file that needs to be archived
+    pub path: PathBuf,
+    /// The job ID
+    pub jobid: String,
+    /// Time of event notification and instance creation
+    pub moment: Instant,
+}
+
+impl SlurmJobEntry {
+    pub fn new(p: &PathBuf, id: &str) -> SlurmJobEntry {
+        SlurmJobEntry {
+            path: p.clone(),
+            jobid: id.to_string(),
+            moment: Instant::now(),
+        }
+    }
+}


### PR DESCRIPTION
For future expansion, it would be beneficial if the code is made more modular, so we can have different backends, differentiations schedulers (so we can merge with the Torque backend).

- Create an archive module, and move everything related to file copy there
- Create a slurm module, later to be moved to some `scheduler/slurm` module
- Move tests to the right module