### PR TITLE
Elastic output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ notify = { git = "https://github.com/passcod/notify", branch = "main", commit = 
 libc = "0.2.60"
 log = "^0.4"
 reopen = "^0.3.0"
+serde = "~1"
+serde_derive = "~1"
 syslog = "4.0.1"
 signal-hook = "^0.1.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sarchive"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Andy Georges <itkovian@gmail.com>"]
 edition = "2018"
 description = "Archiving tool for slurm job scripts"
@@ -22,6 +22,8 @@ crossbeam = "0.7.2"
 crossbeam-channel = "0.3.9"
 crossbeam-queue = "0.1.2"
 crossbeam-utils = "0.6.6"
+elastic = "~0.21.0-pre.5"
+elastic_derive = "~0.21.0-pre.5"
 fern = { git = "https://github.com/daboross/fern", branch = "master", commit = " 1c8fd50", features = ["reopen-03"]}
 #notify = "5.0.0-pre.1"
 notify = { git = "https://github.com/passcod/notify", branch = "main", commit = "0709c94" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ elastic = "~0.21.0-pre.5"
 elastic_derive = "~0.21.0-pre.5"
 fern = { git = "https://github.com/daboross/fern", branch = "master", commit = " 1c8fd50", features = ["reopen-03"]}
 futures = "0.1.28"
-#notify = "5.0.0-pre.1"
 notify = { git = "https://github.com/passcod/notify", branch = "main", commit = "0709c94" }
 libc = "0.2.60"
 log = "^0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "itkovian/sarchive" }
 coveralls = { repository = "itkovian/sarchive" }
 
 [dependencies]
-chrono = "0.4.7"
+chrono = { version = "0.4.7", features = ["serde"] }
 clap = "2.33"
 crossbeam = "0.7.2"
 crossbeam-channel = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ crossbeam-utils = "0.6.6"
 elastic = "~0.21.0-pre.5"
 elastic_derive = "~0.21.0-pre.5"
 fern = { git = "https://github.com/daboross/fern", branch = "master", commit = " 1c8fd50", features = ["reopen-03"]}
+futures = "0.1.28"
 #notify = "5.0.0-pre.1"
 notify = { git = "https://github.com/passcod/notify", branch = "main", commit = "0709c94" }
 libc = "0.2.60"
@@ -32,6 +33,7 @@ log = "^0.4"
 reopen = "^0.3.0"
 serde = "~1"
 serde_derive = "~1"
+serde_json = "~1"
 syslog = "4.0.1"
 signal-hook = "^0.1.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sarchive"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Andy Georges <itkovian@gmail.com>"]
 edition = "2018"
 description = "Archiving tool for slurm job scripts"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This version is what we test against in CI. We also test on
   - beta
   - nightly
 
-for both Linux and MaxOS.
+for both Linux and MacOS.
 
 If you do not have [Rust](https://rustlang.org), please see [Rustup](https://rustup.rs) for installation instructions.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Archival tool for Slurm job scripts and accompanying environments.
 
 `1.34.2+`
 
-This version is what we test against in CI. We also test on 
+This version is what we test against in CI. We also test on
   - stable
   - beta
   - nightly
@@ -25,14 +25,14 @@ If you do not have [Rust](https://rustlang.org), please see [Rustup](https://rus
 
 `sarchive` requires that two paths are provided:
   - The Slurm spool directory where the `hash.[0-9]` directories can be found
-  - The archive directory, where the copied scripts and environments will be 
+  - The archive directory, where the copied scripts and environments will be
     stored. This directory is created, if it does not exist.
 
 The archive can be further divided into subdirectories per
   - year: YYYY, by provinging `--period=yearly`
   - month: YYYYMM, by providing `--period=montly`
   - day: YYYYMMDD, by providing `--period=daily`
-This allows for easily tarring old(er) directories you still wish to keep around, 
+This allows for easily tarring old(er) directories you still wish to keep around,
 but probably no longer immediately need for user support. Each of these directories
 are also created upon file archival if they do not exist.
 
@@ -46,10 +46,11 @@ are also created upon file archival if they do not exist.
 - Experimental support for clean termination on receipt of SIGTERM or SIGINT, where
   job events that have already been seen are processed, to minimise potential loss
   when restarting the service.
+- Output to Elasticsearch
 
 ## RPMs
 
-We provide a build script to generate an RPM using the cargo-rpm tool. You may tailor the spec 
+We provide a build script to generate an RPM using the cargo-rpm tool. You may tailor the spec
 file (listed under the `.rpm` directory) to fit your needs. The RPM includes a unit file so
 `sarchive` can be started as a service by systemd. This file should also be changed to fit your
 requirements and local configuration.

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -23,11 +23,41 @@ SOFTWARE.
 use super::Archive;
 use crate::slurm::SlurmJobEntry;
 use chrono::{DateTime, Utc};
+use clap::{App, Arg, SubCommand};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Error;
 use std::process::exit;
 
+/// Command line options for the elastic archiver subcommand
+pub fn clap_subcommand(command: &str) -> App {
+    SubCommand::with_name(command)
+        .about("Archive to ElasticSearch")
+        /*.arg(
+            Arg::with_name("auth")
+        )*/
+        .arg(
+            Arg::with_name("host")
+                .long("host")
+                .takes_value(true)
+                .default_value("localhost")
+                .help("The hostname of the ElasticSearch server"),
+        )
+        .arg(
+            Arg::with_name("port")
+                .long("port")
+                .takes_value(true)
+                .default_value("9200")
+                .help("The port of the ElasticSearch service"),
+        )
+        .arg(
+            Arg::with_name("index")
+                .long("index")
+                .takes_value(true)
+                .required(true)
+                .help("The index where the documents will be put"),
+        )
+}
 //use elastic::http::header::{self, AUTHORIZATION, HeaderValue};
 use elastic::client::{SyncClient, SyncClientBuilder};
 

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -20,20 +20,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
 use std::io::Error;
 use super::Archive;
 use crate::slurm::{SlurmJobEntry};
 
+use elastic::http::header::{self, AUTHORIZATION, HeaderValue};
+use elastic::client::{AsyncClient, AsyncClientBuilder};
+
+
 pub struct ElasticArchive {
-    host: String,
-    port: u16,
+    client: AsyncClient
 }
 
 impl ElasticArchive {
     pub fn new(host: &str, port: u16) -> Self {
         ElasticArchive {
-            host: host.to_owned(),
-            port: port,
+            client: AsyncClientBuilder::new()
+                .sniff_nodes(format!("http://{host}:{port}", host=host, port=port))  // TODO: use a pool for serde
+                .build().unwrap(),
         }
     }
 }
@@ -42,7 +48,18 @@ impl ElasticArchive {
 impl Archive for ElasticArchive {
 
     fn archive(&self, slurm_job_entry: &SlurmJobEntry) -> Result<(), Error> {
+
+
+
         Ok(())
     }
 
+}
+
+
+#[derive(Serialize, Deserialize, ElasticType)]
+struct JobInfo {
+    pub id: String,
+    pub script: String,
+    pub environment: HashMap<String, String>,
 }

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -96,7 +96,7 @@ impl Archive for ElasticArchive {
 
         let doc = JobInfo {
             id: slurm_job_entry.jobid.to_owned(),
-            script: String::from("test"),
+            script: script,
             environment: HashMap::new(),
         };
         let _res = self.client.document()

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -20,13 +20,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-pub mod elastic;
-pub mod file;
-
 use std::io::Error;
-use super::slurm;
+use super::Archive;
+use crate::slurm::{SlurmJobEntry};
 
-/// The Archive trait should be implemented by every backend.
-pub trait Archive {
-    fn archive(&self, slurm_job_entry: &slurm::SlurmJobEntry) -> Result<(), Error>;
+pub struct ElasticArchive {
+    host: String,
+    port: u16,
+}
+
+impl ElasticArchive {
+    pub fn new(host: &str, port: u16) -> Self {
+        ElasticArchive {
+            host: host.to_owned(),
+            port: port,
+        }
+    }
+}
+
+
+impl Archive for ElasticArchive {
+
+    fn archive(&self, slurm_job_entry: &SlurmJobEntry) -> Result<(), Error> {
+        Ok(())
+    }
+
 }

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -22,7 +22,7 @@ SOFTWARE.
 
 use super::Archive;
 use crate::slurm::SlurmJobEntry;
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Error;
@@ -33,7 +33,7 @@ use elastic::client::{SyncClient, SyncClientBuilder};
 
 pub struct ElasticArchive {
     client: SyncClient,
-    index: String,
+    //index: String,
 }
 
 fn create_index(client: &SyncClient, index_name: String) -> Result<(), Error> {
@@ -90,7 +90,7 @@ impl ElasticArchive {
         // We create the index if it does not exist
         if let Ok(response) = client.index(index.to_owned()).exists().send() {
             if !response.exists() {
-                create_index(&client, index.to_owned());
+                create_index(&client, index.to_owned()).unwrap();
             }
         } else {
             error!("Cannot check if index exists. Quitting.");
@@ -104,8 +104,8 @@ impl ElasticArchive {
         //}
 
         ElasticArchive {
-            client: client,
-            index: index.to_owned(),
+            client,
+            //index: index.to_owned(),
         }
     }
 }
@@ -123,7 +123,7 @@ impl Archive for ElasticArchive {
         let doc = JobInfo {
             id: slurm_job_entry.jobid.to_owned(),
             timestamp: Utc::now(),
-            script: script,
+            script,
             environment: env,
         };
         let _res = self.client.document().index(doc).send().unwrap();

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -20,9 +20,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#![recursion_limit="128"]
-
-//use futures::future::Future;
 use chrono::{DateTime, Local, Utc};
 use serde::{Serialize, Deserialize};
 use std::collections::HashMap;

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -97,7 +97,7 @@ impl Archive for ElasticArchive {
         let doc = JobInfo {
             id: slurm_job_entry.jobid.to_owned(),
             script: script,
-            environment: HashMap::new(),
+            environment: env,
         };
         let _res = self.client.document()
             .index(doc)

--- a/src/archive/elastic.rs
+++ b/src/archive/elastic.rs
@@ -23,7 +23,7 @@ SOFTWARE.
 use super::Archive;
 use crate::slurm::SlurmJobEntry;
 use chrono::{DateTime, Utc};
-use clap::{App, Arg, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Error;
@@ -137,6 +137,15 @@ impl ElasticArchive {
             client,
             //index: index.to_owned(),
         }
+    }
+
+    pub fn build(matches: &ArgMatches) -> Result<Self, Error> {
+        info!("Using ElasticSearch archival");
+        Ok(ElasticArchive::new(
+            matches.value_of("host").unwrap(),
+            matches.value_of("port").unwrap().parse::<u16>().unwrap(),
+            matches.value_of("index").unwrap().to_owned(),
+        ))
     }
 }
 

--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -27,8 +27,20 @@ use std::thread::sleep;
 
 use super::{Archive};
 use super::super::slurm::{SlurmJobEntry};
-use super::super::utils::{Period};
 
+/// An enum to define a hierachy in the archive
+pub enum Period {
+    /// Leads to a YYYYMMDD subdir
+    Daily,
+    /// Leads to a YYYYMM subdir
+    Monthly,
+    /// Leads to a YYYY subdir
+    Yearly,
+    /// No subdir
+    None,
+}
+
+/// An aerchiver that writes job script info to a file
 pub struct FileArchive {
     archive_path: PathBuf,
     period: Period,
@@ -42,7 +54,6 @@ impl FileArchive {
         }
     }
 }
-
 
 impl Archive for FileArchive {
     /// Archives the files from the given SlurmJobEntry's path.

--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -1,0 +1,237 @@
+/*
+Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+use std::fs::{copy, create_dir_all};
+use std::io::Error;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use std::thread::sleep;
+
+use super::{Archive};
+use super::super::slurm::{SlurmJobEntry};
+use super::super::utils::{Period};
+
+pub struct FileArchive {
+    archive_path: PathBuf,
+    period: Period,
+}
+
+impl FileArchive {
+    pub fn new(archive_path: &PathBuf, p: Period) -> Self {
+        FileArchive {
+            archive_path: archive_path.clone(),
+            period: p,
+        }
+    }
+}
+
+
+impl Archive for FileArchive {
+    /// Archives the files from the given SlurmJobEntry's path.
+    ///
+    /// We busy wait for 1 second, sleeping for 10 ms per turn for
+    /// the environment and script files to appear.
+    /// If the files cannot be found after that tine, we output a warning
+    /// and return without copying.
+    /// If the directory dissapears before we found or copied the files,
+    /// we panic.
+    fn archive(&self, slurm_job_entry: &SlurmJobEntry) -> Result<(), Error> {
+        // Simulate the debounced event we had before. Wait two seconds after dir creation event to
+        // have some assurance the files will have been written.
+        if slurm_job_entry.moment.elapsed().as_secs() < 2 {
+            sleep(Duration::from_millis(2000) - slurm_job_entry.moment.elapsed());
+        }
+        let ten_millis = Duration::from_millis(10);
+        // We wait for each file to be present
+
+        let archive_path = &self.archive_path;
+        let p = &self.period;
+        for filename in &["script", "environment"] {
+            let fpath = slurm_job_entry.path.join(filename);
+            let mut iters = 100;
+            while !Path::exists(&fpath) && iters > 0 {
+                debug!("Waiting for {:?}", fpath);
+                sleep(ten_millis);
+                if !Path::exists(&slurm_job_entry.path) {
+                    error!("Job directory {:?} no longer exists", &slurm_job_entry.path);
+                    panic!("path not found");
+                }
+                iters -= 1;
+            }
+            if iters == 0 {
+                warn!("Cannot make copy of {:?}", fpath);
+                continue;
+            }
+
+            let target_path = determine_target_path(&archive_path, &p, &slurm_job_entry, &filename);
+
+            match copy(&fpath, &target_path) {
+                Ok(bytes) => info!(
+                    "copied {} bytes from {:?} to {:?}",
+                    bytes, &fpath, &target_path
+                ),
+                Err(e) => {
+                    error!(
+                        "Copy of {:?} to {:?} failed: {:?}",
+                        &slurm_job_entry.path, &target_path, e
+                    );
+                    return Err(e);
+                }
+            };
+        }
+
+        Ok(())
+    }
+
+}
+
+/// Determines the target path for the slurm job file
+///
+/// The path will have the following components:
+/// - the archive path
+/// - a subdir depending on the Period
+///     - YYYY in case of a Yearly Period
+///     - YYYYMM in case of a Monthly Period
+///     - YYYYMMDD in case of a Daily Period
+/// - a file with the given filename
+fn determine_target_path(
+    archive_path: &Path,
+    p: &Period,
+    slurm_job_entry: &SlurmJobEntry,
+    filename: &str,
+) -> PathBuf {
+    let archive_subdir = match p {
+        Period::Yearly => Some(format!("{}", chrono::Local::now().format("%Y"))),
+        Period::Monthly => Some(format!("{}", chrono::Local::now().format("%Y%m"))),
+        Period::Daily => Some(format!("{}", chrono::Local::now().format("%Y%m%d"))),
+        _ => None,
+    };
+    debug!("Archive subdir is {:?}", &archive_subdir);
+    match archive_subdir {
+        Some(d) => {
+            let archive_subdir_path = archive_path.join(&d);
+            if !Path::exists(&archive_subdir_path) {
+                debug!("Archive subdir {:?} does not yet exist, creating", &d);
+                create_dir_all(&archive_subdir_path).unwrap();
+            }
+            archive_subdir_path
+                .clone()
+                .join(format!("job.{}_{}", &slurm_job_entry.jobid, &filename))
+        }
+        None => archive_path.join(format!("job.{}_{}", &slurm_job_entry.jobid, &filename)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    extern crate tempfile;
+
+    use super::*;
+    use std::fs::{create_dir, read_to_string, File};
+    use std::io::Write;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_is_job_path() {
+        let tdir = tempdir().unwrap();
+
+        // this should pass
+        let jobdir = tdir.path().join("job.1234");
+        let _dir = create_dir(&jobdir);
+        assert_eq!(is_job_path(&jobdir), Some(("1234", "job.1234")));
+
+        // this should fail
+        let fdir = tdir.path().join("fubar");
+        let _faildir = create_dir(&fdir);
+        assert_eq!(is_job_path(&fdir), None);
+    }
+
+    #[test]
+    fn test_determine_target_path() {
+        let tdir = tempdir().unwrap();
+
+        // create the basic archive path
+        let archive_dir = tdir.path();
+        let _dir = create_dir(&archive_dir);
+        let slurm_job_entry = slurm::SlurmJobEntry::new(&PathBuf::from("/tmp/some/job/path"), "1234");
+
+        let p = Period::None;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(format!("job.1234_foobar")));
+
+        let d = format!("{}", chrono::Local::now().format("%Y"));
+        let p = Period::Yearly;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(d).join("job.1234_foobar"));
+
+        let d = format!("{}", chrono::Local::now().format("%Y%m"));
+        let p = Period::Monthly;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(d).join("job.1234_foobar"));
+
+        let d = format!("{}", chrono::Local::now().format("%Y%m%d"));
+        let p = Period::Daily;
+        let target_path = determine_target_path(&archive_dir, &p, &slurm_job_entry, "foobar");
+
+        assert_eq!(target_path, archive_dir.join(d).join("job.1234_foobar"));
+    }
+
+    #[test]
+    fn test_archive() {
+        let tdir = tempdir().unwrap();
+
+        // create the basic archive path
+        let archive_dir = tdir.path().join("archive");
+        let _dir = create_dir(&archive_dir);
+
+        // create the basic job path
+        let job_dir = tdir.path().join("job.1234");
+        let _dir = create_dir(&job_dir);
+
+        // create env and script files
+        let env_path = job_dir.join("environment");
+        let mut env = File::create(env_path).unwrap();
+        env.write(b"environment");
+
+        let job_path = job_dir.join("script");
+        let mut job = File::create(&job_path).unwrap();
+        job.write(b"job script");
+
+        let slurm_job_entry = slurm::SlurmJobEntry::new(&job_dir, "1234");
+
+        archive(&archive_dir, &Period::None, &slurm_job_entry);
+
+        assert!(Path::is_file(&archive_dir.join("job.1234_environment")));
+        assert!(Path::is_file(&archive_dir.join("job.1234_script")));
+
+        let archive_env_contents =
+            read_to_string(&archive_dir.join("job.1234_environment")).unwrap();
+        assert_eq!(&archive_env_contents, "environment");
+
+        let archive_script_contents = read_to_string(&archive_dir.join("job.1234_script")).unwrap();
+        assert_eq!(&archive_script_contents, "job script");
+    }
+}

--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -22,7 +22,7 @@ SOFTWARE.
 use std::fs::{copy, create_dir_all};
 use std::io::Error;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::thread::sleep;
 
 use super::{Archive};

--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -26,7 +26,7 @@ use std::time::{Duration, Instant};
 use std::thread::sleep;
 
 use super::{Archive};
-use super::super::slurm::{SlurmJobEntry};
+use crate::slurm::{SlurmJobEntry};
 
 /// An enum to define a hierachy in the archive
 pub enum Period {

--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -19,6 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+use clap::{App, Arg, SubCommand};
 use std::fs::{copy, create_dir_all};
 use std::io::Error;
 use std::path::{Path, PathBuf};
@@ -27,6 +28,38 @@ use std::time::Duration;
 
 use super::super::slurm::SlurmJobEntry;
 use super::Archive;
+
+/// Command line options for the file archiver subcommand
+pub fn clap_subcommand(command: &str) -> App {
+    SubCommand::with_name(command)
+        .about("Archive to the filesystem")
+        .arg(
+            Arg::with_name("archive")
+                .long("archive")
+                .short("a")
+                .takes_value(true)
+                .help("Location of the job scripts' archive."),
+        )
+        .arg(
+            Arg::with_name("logfile")
+                .long("logfile")
+                .short("l")
+                .takes_value(true)
+                .help("Log file name.")
+        )
+        .arg(
+            Arg::with_name("period")
+                .long("period")
+                .short("p")
+                .takes_value(true)
+                .possible_value("yearly")
+                .possible_value("monthly")
+                .possible_value("daily")
+                .help(
+                    "Archive under a YYYY subdirectory (yearly), YYYYMM (monthly), or YYYYMMDD (daily)."
+                )
+        )
+}
 
 /// An enum to define a hierachy in the archive
 pub enum Period {

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -27,6 +27,6 @@ use std::io::Error;
 use super::slurm;
 
 /// The Archive trait should be implemented by every backend.
-pub trait Archive {
+pub trait Archive: Send {
     fn archive(&self, slurm_job_entry: &slurm::SlurmJobEntry) -> Result<(), Error>;
 }

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+pub mod file;
+
+use std::io::Error;
+use super::slurm;
+
+/// The Archive trait should be implemented by every backend.
+pub trait Archive {
+    fn archive(&self, slurm_job_entry: &slurm::SlurmJobEntry) -> Result<(), Error>;
+}

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -23,10 +23,30 @@ SOFTWARE.
 pub mod elastic;
 pub mod file;
 
+use self::elastic::ElasticArchive;
 use super::slurm;
-use std::io::Error;
+use clap::ArgMatches;
+use file::FileArchive;
+use std::io::{Error, ErrorKind};
 
 /// The Archive trait should be implemented by every backend.
 pub trait Archive: Send {
     fn archive(&self, slurm_job_entry: &slurm::SlurmJobEntry) -> Result<(), Error>;
+}
+
+pub fn archive_builder(matches: &ArgMatches) -> Result<Box<dyn Archive>, Error> {
+    match matches.subcommand() {
+        ("file", Some(command_matches)) => {
+            let archive = FileArchive::build(command_matches)?;
+            Ok(Box::new(archive))
+        }
+        ("elasticsearch", Some(run_matches)) => {
+            let archive = ElasticArchive::build(run_matches)?;
+            Ok(Box::new(archive))
+        }
+        (&_, _) => Err(Error::new(
+            ErrorKind::Other,
+            "No supported archival subcommand used",
+        )),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,7 @@ fn archive_builder(matches: &ArgMatches) -> Box<dyn Archive> {
     }
 }
 
-fn register_signal_handler(signal: i32, unparker: &Unparker, notification: &Arc<AtomicBool>) -> () {
+fn register_signal_handler(signal: i32, unparker: &Unparker, notification: &Arc<AtomicBool>) {
     info!("Registering signal handler for signal {}", signal);
     let u1 = unparker.clone();
     let n1 = Arc::clone(&notification);

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ extern crate libc;
 #[macro_use] extern crate log;
 extern crate notify;
 extern crate reopen;
+#[macro_use] extern crate serde_json;
 extern crate syslog;
 
 use clap::{App, Arg, SubCommand};
@@ -156,6 +157,13 @@ fn main() {
                     .default_value("9200")
                     .help("The port of the ElasticSearch service")
             )
+            .arg(
+                Arg::with_name("index")
+                    .long("index")
+                    .takes_value(true)
+                    .required(true)
+                    .help("The index where the documents will be put")
+            )
         )
         .get_matches();
 
@@ -178,7 +186,7 @@ fn main() {
         exit(1);
     }
 
-    let archiver: Box<Archive> = match matches.subcommand() {
+    let archiver: Box<dyn Archive> = match matches.subcommand() {
         ("file", Some(command_matches)) => {
             let archive = Path::new(
                 command_matches
@@ -210,7 +218,8 @@ fn main() {
             info!("Using ElasticSearch archival");
             Box::new(ElasticArchive::new(
                 run_matches.value_of("host").unwrap(),
-                run_matches.value_of("port").unwrap().parse::<u16>().unwrap()
+                run_matches.value_of("port").unwrap().parse::<u16>().unwrap(),
+                run_matches.value_of("index").unwrap().to_owned()
             ))
         },
         (&_, _) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ extern crate notify;
 extern crate reopen;
 extern crate syslog;
 
-use clap::{App, Arg};
+use clap::{App, Arg, SubCommand};
 use crossbeam_channel::{bounded, unbounded};
 use crossbeam_utils::sync::Parker;
 use crossbeam_utils::thread::scope;
@@ -99,25 +99,6 @@ fn main() {
                 .help("Log at DEBUG level.")
         )
         .arg(
-            Arg::with_name("logfile")
-                .long("logfile")
-                .short("l")
-                .takes_value(true)
-                .help("Log file name.")
-        )
-        .arg(
-            Arg::with_name("period")
-                .long("period")
-                .short("p")
-                .takes_value(true)
-                .possible_value("yearly")
-                .possible_value("monthly")
-                .possible_value("daily")
-                .help(
-                    "Archive under a YYYY subdirectory (yearly), YYYYMM (monthly), or YYYYMMDD (daily)."
-                )
-        )
-        .arg(
             Arg::with_name("cleanup")
                 .long("cleanup")
                 .help(
@@ -132,6 +113,43 @@ fn main() {
                 .help(
                     "Location of the Slurm StateSaveLocation (where the job hash dirs are kept).",
                 )
+        )
+        .subcommand(SubCommand::with_name("file")
+            .about("Archive to the filesystem")
+            .arg(
+                Arg::with_name("logfile")
+                    .long("logfile")
+                    .short("l")
+                    .takes_value(true)
+                    .help("Log file name.")
+            )
+            .arg(
+                Arg::with_name("period")
+                    .long("period")
+                    .short("p")
+                    .takes_value(true)
+                    .possible_value("yearly")
+                    .possible_value("monthly")
+                    .possible_value("daily")
+                    .help(
+                        "Archive under a YYYY subdirectory (yearly), YYYYMM (monthly), or YYYYMMDD (daily)."
+                    )
+            )
+        )
+        .subcommand(SubCommand::with_name("elasticsearch")
+            .about("Archive to ElasticSearch")
+            .arg(
+                Arg::with_name("host")
+                    .long("host")
+                    .takes_value(true)
+                    .help("The hostname of the ElasticSearch server")
+            )
+            .arg(
+                Arg::with_name("post")
+                    .long("port")
+                    .takes_value(true)
+                    .help("The port of the ElasticSearch service")
+            )
         )
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,6 @@ extern crate chrono;
 extern crate clap;
 extern crate crossbeam_channel;
 extern crate crossbeam_utils;
-extern crate elastic;
-#[macro_use] extern crate elastic_derive;
 extern crate fern;
 extern crate libc;
 #[macro_use] extern crate log;
@@ -47,7 +45,8 @@ mod archive;
 mod slurm;
 mod utils;
 
-use utils::{monitor, process, signal_handler_atomic, Period};
+use utils::{monitor, process, signal_handler_atomic};
+use archive::file::{FileArchive, Period};
 
 
 fn setup_logging(
@@ -213,7 +212,7 @@ fn main() {
     let (sig_sender, sig_receiver) = bounded(20);
 
     let cleanup = matches.is_present("cleanup");
-    let file_archiver = archive::file::FileArchive::new(&archive.to_path_buf(), period);
+    let file_archiver = FileArchive::new(&archive.to_path_buf(), period);
 
     // we will watch the ten hash.X directories
     let (sender, receiver) = unbounded();

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ extern crate reopen;
 extern crate serde_json;
 extern crate syslog;
 
-use clap::{App, Arg, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use crossbeam_channel::{bounded, unbounded};
 use crossbeam_utils::sync::Parker;
 use crossbeam_utils::thread::scope;
@@ -82,8 +82,8 @@ fn setup_logging(
     .apply()
 }
 
-fn main() {
-    let matches = App::new("SArchive")
+fn args<'a>() -> ArgMatches<'a> {
+    App::new("SArchive")
         .version("0.6.0")
         .author("Andy Georges <itkovian+sarchive@gmail.com>")
         .about("Archive slurm user job scripts.")
@@ -168,8 +168,11 @@ fn main() {
                     .help("The index where the documents will be put")
             )
         )
-        .get_matches();
+        .get_matches()
+}
 
+fn main() {
+    let matches = args();
     let log_level = if matches.is_present("debug") {
         log::LevelFilter::Debug
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ extern crate reopen;
 extern crate serde_json;
 extern crate syslog;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches};
 use crossbeam_channel::{bounded, unbounded};
 use crossbeam_utils::sync::{Parker, Unparker};
 use crossbeam_utils::thread::scope;
@@ -51,7 +51,9 @@ mod archive;
 mod slurm;
 mod utils;
 
+use archive::elastic as el;
 use archive::elastic::ElasticArchive;
+use archive::file;
 use archive::file::{FileArchive, Period};
 use archive::Archive;
 use utils::{monitor, process, signal_handler_atomic};
@@ -115,62 +117,8 @@ fn args<'a>() -> ArgMatches<'a> {
                     "Location of the Slurm StateSaveLocation (where the job hash dirs are kept).",
                 )
         )
-        .subcommand(SubCommand::with_name("file")
-            .about("Archive to the filesystem")
-            .arg(
-                Arg::with_name("archive")
-                    .long("archive")
-                    .short("a")
-                    .takes_value(true)
-                    .help("Location of the job scripts' archive."),
-            )
-            .arg(
-                Arg::with_name("logfile")
-                    .long("logfile")
-                    .short("l")
-                    .takes_value(true)
-                    .help("Log file name.")
-            )
-            .arg(
-                Arg::with_name("period")
-                    .long("period")
-                    .short("p")
-                    .takes_value(true)
-                    .possible_value("yearly")
-                    .possible_value("monthly")
-                    .possible_value("daily")
-                    .help(
-                        "Archive under a YYYY subdirectory (yearly), YYYYMM (monthly), or YYYYMMDD (daily)."
-                    )
-            )
-        )
-        .subcommand(SubCommand::with_name("elasticsearch")
-            .about("Archive to ElasticSearch")
-            /*.arg(
-                Arg::with_name("auth")
-            )*/
-            .arg(
-                Arg::with_name("host")
-                    .long("host")
-                    .takes_value(true)
-                    .default_value("localhost")
-                    .help("The hostname of the ElasticSearch server")
-            )
-            .arg(
-                Arg::with_name("port")
-                    .long("port")
-                    .takes_value(true)
-                    .default_value("9200")
-                    .help("The port of the ElasticSearch service")
-            )
-            .arg(
-                Arg::with_name("index")
-                    .long("index")
-                    .takes_value(true)
-                    .required(true)
-                    .help("The index where the documents will be put")
-            )
-        )
+        .subcommand(file::clap_subcommand("file"))
+        .subcommand(el::clap_subcommand("elasticsearch"))
         .get_matches()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,8 @@ use archive::file::{FileArchive, Period};
 use archive::Archive;
 use utils::{monitor, process, signal_handler_atomic};
 
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 fn setup_logging(
     level_filter: log::LevelFilter,
     logfile: Option<&str>,
@@ -86,7 +88,7 @@ fn setup_logging(
 
 fn args<'a>() -> ArgMatches<'a> {
     App::new("SArchive")
-        .version("0.6.0")
+        .version(VERSION)
         .author("Andy Georges <itkovian+sarchive@gmail.com>")
         .about("Archive slurm user job scripts.")
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,12 +146,14 @@ fn main() {
                 Arg::with_name("host")
                     .long("host")
                     .takes_value(true)
+                    .default_value("localhost")
                     .help("The hostname of the ElasticSearch server")
             )
             .arg(
-                Arg::with_name("post")
+                Arg::with_name("port")
                     .long("port")
                     .takes_value(true)
+                    .default_value("9200")
                     .help("The port of the ElasticSearch service")
             )
         )
@@ -204,7 +206,8 @@ fn main() {
 
             Box::new(FileArchive::new(&archive.to_path_buf(), period))
         },
-        ("elastic", Some(run_matches)) => {
+        ("elasticsearch", Some(run_matches)) => {
+            info!("Using ElasticSearch archival");
             Box::new(ElasticArchive::new(
                 run_matches.value_of("host").unwrap(),
                 run_matches.value_of("port").unwrap().parse::<u16>().unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,6 @@ fn archive_builder(matches: &ArgMatches) -> Box<dyn Archive> {
 }
 
 fn register_signal_handler(signal: i32, unparker: &Unparker, notification: &Arc<AtomicBool>) -> () {
-
     info!("Registering signal handler for signal {}", signal);
     let u1 = unparker.clone();
     let n1 = Arc::clone(&notification);
@@ -238,7 +237,6 @@ fn register_signal_handler(signal: i32, unparker: &Unparker, notification: &Arc<
         }
     };
 }
-
 
 fn main() {
     let matches = args();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,9 @@ mod archive;
 mod slurm;
 mod utils;
 
+use archive::elastic::ElasticArchive;
 use archive::file::{FileArchive, Period};
+use archive::Archive;
 use utils::{monitor, process, signal_handler_atomic};
 
 fn setup_logging(
@@ -293,7 +295,7 @@ fn main() {
         }
         let r = &receiver;
         let sr = &sig_receiver;
-        s.spawn(move |_| process(&archiver, r, sr, cleanup));
+        s.spawn(move |_| process(archiver, r, sr, cleanup));
     }) {
         error!("sarchive stopping due to error: {:?}", e);
         exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,26 +214,26 @@ fn main() {
             };
 
             Box::new(FileArchive::new(&archive.to_path_buf(), period))
-        },
+        }
         ("elasticsearch", Some(run_matches)) => {
             info!("Using ElasticSearch archival");
             Box::new(ElasticArchive::new(
                 run_matches.value_of("host").unwrap(),
-                run_matches.value_of("port").unwrap().parse::<u16>().unwrap(),
-                run_matches.value_of("index").unwrap().to_owned()
+                run_matches
+                    .value_of("port")
+                    .unwrap()
+                    .parse::<u16>()
+                    .unwrap(),
+                run_matches.value_of("index").unwrap().to_owned(),
             ))
-        },
+        }
         (&_, _) => {
             error!("No matching subcommand used, exiting");
             exit(1);
         }
     };
 
-    info!(
-        "sarchive starting. Watching hash dirs in {:?}.",
-        &base
-    );
-
+    info!("sarchive starting. Watching hash dirs in {:?}.", &base);
 
     let notification = Arc::new(AtomicBool::new(false));
     let parker = Parker::new();

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -19,6 +19,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+use std::collections::HashMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -42,11 +44,11 @@ impl SlurmJobEntry {
     }
 
     pub fn read_script(&self) -> String {
-        String::from("script contents")
+        fs::read_to_string(self.path.join("script")).expect(&format!("Could not read file {:?}/script", self.path))
     }
 
-    pub fn read_env(&self) -> String {
-        String::from("env contents")
+    pub fn read_env(&self) -> HashMap<&str, &str> {
+        HashMap::new()
     }
 }
 

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -44,11 +44,13 @@ impl SlurmJobEntry {
     }
 
     pub fn read_script(&self) -> String {
-        fs::read_to_string(self.path.join("script")).expect(&format!("Could not read file {:?}/script", self.path))
+        fs::read_to_string(self.path.join("script"))
+            .expect(&format!("Could not read file {:?}/script", self.path))
     }
 
     pub fn read_env(&self) -> HashMap<String, String> {
-        let s = fs::read_to_string(self.path.join("environment")).expect(&format!("Could not read file {:?}/environment", self.path));
+        let s = fs::read_to_string(self.path.join("environment"))
+            .expect(&format!("Could not read file {:?}/environment", self.path));
 
         s.split('\0')
             .filter(|s| s.len() > 0)
@@ -61,7 +63,6 @@ impl SlurmJobEntry {
                 }
             })
             .collect()
-
     }
 }
 

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// Representation of an entry in the Slurm job spool hash directories
+pub struct SlurmJobEntry {
+    /// The full path to the file that needs to be archived
+    pub path: PathBuf,
+    /// The job ID
+    pub jobid: String,
+    /// Time of event notification and instance creation
+    pub moment: Instant,
+}
+
+impl SlurmJobEntry {
+    pub fn new(p: &PathBuf, id: &str) -> SlurmJobEntry {
+        SlurmJobEntry {
+            path: p.clone(),
+            jobid: id.to_string(),
+            moment: Instant::now(),
+        }
+    }
+}

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -47,8 +47,21 @@ impl SlurmJobEntry {
         fs::read_to_string(self.path.join("script")).expect(&format!("Could not read file {:?}/script", self.path))
     }
 
-    pub fn read_env(&self) -> HashMap<&str, &str> {
-        HashMap::new()
+    pub fn read_env(&self) -> HashMap<String, String> {
+        let s = fs::read_to_string(self.path.join("environment")).expect(&format!("Could not read file {:?}/environment", self.path));
+
+        s.split('\0')
+            .filter(|s| s.len() > 0)
+            .map(|s| {
+                let ps: Vec<_> = s.split('=').collect();
+                if ps.len() == 2 {
+                    (ps[0].to_owned(), ps[1].to_owned())
+                } else {
+                    (s.to_owned(), String::from(""))
+                }
+            })
+            .collect()
+
     }
 }
 

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// Representation of an entry in the Slurm job spool hash directories
 pub struct SlurmJobEntry {

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -40,6 +40,14 @@ impl SlurmJobEntry {
             moment: Instant::now(),
         }
     }
+
+    pub fn read_script(&self) -> String {
+        String::from("script contents")
+    }
+
+    pub fn read_env(&self) -> String {
+        String::from("env contents")
+    }
 }
 
 /// Verifies that the path metioned in the event is a that of a file that

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -45,15 +45,15 @@ impl SlurmJobEntry {
 
     pub fn read_script(&self) -> String {
         fs::read_to_string(self.path.join("script"))
-            .expect(&format!("Could not read file {:?}/script", self.path))
+            .unwrap_or_else(|_| panic!("Could not read file {:?}/script", self.path))
     }
 
     pub fn read_env(&self) -> HashMap<String, String> {
         let s = fs::read_to_string(self.path.join("environment"))
-            .expect(&format!("Could not read file {:?}/environment", self.path));
+            .unwrap_or_else(|_| panic!("Could not read file {:?}/environment", self.path));
 
         s.split('\0')
-            .filter(|s| s.len() > 0)
+            .filter(|s| !s.is_empty())
             .map(|s| {
                 let ps: Vec<_> = s.split('=').collect();
                 if ps.len() == 2 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -119,7 +119,7 @@ pub fn monitor(
 /// At the same time, it also checks if there is an incoming notification that it should
 /// stop processing. Upon receipt, it will cease operations immediately.
 pub fn process(
-    archiver: &archive::Archive,
+    archiver: &Box<archive::Archive>,
     r: &Receiver<slurm::SlurmJobEntry>,
     sigchannel: &Receiver<bool>,
     cleanup: bool,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,19 +38,6 @@ use std::sync::Arc;
 use crate::archive;
 use super::slurm;
 
-/// An enum to define a hierachy in the archive
-pub enum Period {
-    /// Leads to a YYYYMMDD subdir
-    Daily,
-    /// Leads to a YYYYMM subdir
-    Monthly,
-    /// Leads to a YYYY subdir
-    Yearly,
-    /// No subdir
-    None,
-}
-
-
 /// The check_and_queue function verifies that the inotify event pertains
 /// and actual Slurm job entry and pushes the correct information to the
 /// channel so it can be processed later on.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,7 +102,7 @@ pub fn monitor(
 /// At the same time, it also checks if there is an incoming notification that it should
 /// stop processing. Upon receipt, it will cease operations immediately.
 pub fn process(
-    archiver: &Box<dyn archive::Archive>,
+    archiver: Box<dyn archive::Archive>,
     r: &Receiver<slurm::SlurmJobEntry>,
     sigchannel: &Receiver<bool>,
     cleanup: bool,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,14 +29,11 @@ use crossbeam_utils::Backoff;
 use log::*;
 use notify::event::{Event, EventKind, CreateKind};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use std::fs::{copy, create_dir_all};
 use std::io::Error;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
-use std::thread::sleep;
-use std::time::{Duration, Instant};
 
 use crate::archive;
 use super::slurm;
@@ -119,7 +116,7 @@ pub fn monitor(
 /// At the same time, it also checks if there is an incoming notification that it should
 /// stop processing. Upon receipt, it will cease operations immediately.
 pub fn process(
-    archiver: &Box<archive::Archive>,
+    archiver: &Box<dyn archive::Archive>,
     r: &Receiver<slurm::SlurmJobEntry>,
     sigchannel: &Receiver<bool>,
     cleanup: bool,


### PR DESCRIPTION
Support to send job info (scripts and env) to [Elasticsearch.](https://elastic.co).

- [x] Add subcommands to allow choosing the backend (combining both is not yet possible or planned at this stage).
- [x] Send the environment as a broken down set of key-value pairs
- [ ] Support for authentication
- [ ] Support for ignoring env mappings