### PR TITLE
Fix duration check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sarchive"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["Andy Georges <itkovian@gmail.com>"]
 edition = "2018"
 description = "Archival tool for slurm job scripts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,14 @@ notify = "5.0.0-pre.2"
 libc = "0.2.66"
 log = "^0.4"
 reopen = "^0.3.0"
-signal-hook = "^0.1.12"
+signal-hook = "^0.1.13"
 
 elastic = { version = "~0.21.0-pre.5", optional = true }
 elastic_derive = { version = "~0.21.0-pre.5", optional = true }
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_derive = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
-rdkafka = { version = "0.23.0", optional = true }
+rdkafka = { version = "0.23.1", optional = true }
 
 [lib]
 name = "sarchive"

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -102,9 +102,10 @@ pub fn process(
                 if let Ok(mut job_entry) = entry {
                     // Simulate the debounced event we had before. Wait two seconds after dir creation event to
                     // have some assurance the files will have been written.
-                    if job_entry.moment().elapsed().as_secs() < 2 {
+                    let elapsed = job_entry.moment().elapsed();
+                    if elapsed.as_millis() < 2000 {
                         debug!("Waiting for time to elapse before checking files");
-                        sleep(Duration::from_millis(2000) - job_entry.moment().elapsed());
+                        sleep(Duration::from_millis(2000) - elapsed);
                     }
                     job_entry.read_job_info()?;
                     archiver.archive(&job_entry)?;


### PR DESCRIPTION
This addressed the following error:

~~~~
thread '<unnamed>' panicked at 'overflow when subtracting durations', src/libcore/option.rs:1190:5
~~~~

