### PR TITLE
Monitor deletions and get extra job information

### DIFF
--- a/src/archive/file.rs
+++ b/src/archive/file.rs
@@ -83,7 +83,7 @@ impl FileArchive {
 impl Archive for FileArchive {
     /// Archives the files from the given SlurmJobEntry's path.
     ///
-    fn archive(&self, job_entry: &Box<dyn JobInfo>) -> Result<(), Error> {
+    fn archive_creation(&self, job_entry: &Box<dyn JobInfo>) -> Result<(), Error> {
         let archive_path = &self.archive_path;
         let target_path = determine_target_path(archive_path, &self.period);
         debug!("Target path: {:?}", target_path);
@@ -92,6 +92,10 @@ impl Archive for FileArchive {
             let mut f = File::create(target_path.join(fname))?;
             f.write_all(fcontents)?;
         }
+        Ok(())
+    }
+
+    fn archive_removal(&self, _job_entry: &Box<dyn JobInfo>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -196,7 +200,7 @@ mod tests {
 
         let file_archiver = FileArchive::new(&archive_dir, &Period::None);
         let jobinfo: Box<dyn JobInfo> = Box::new(slurm_job_entry);
-        file_archiver.archive(&jobinfo).unwrap();
+        file_archiver.archive_creation(&jobinfo).unwrap();
 
         assert!(Path::is_file(&archive_dir.join("job.1234_environment")));
         assert!(Path::is_file(&archive_dir.join("job.1234_script")));

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -66,22 +66,22 @@ pub fn archive_builder(archiver: &Archiver) -> Result<Box<dyn Archive>, Error> {
     }
 }
 
-/// The process function consumes job entries and call the archive function for each
+/// The process function consumes creation job entries and calls the archive function for each
 /// received entry.
 /// At the same time, it also checks if there is an incoming notification that it should
 /// stop processing. Upon receipt, it will cease operations immediately.
-pub fn process(
+pub fn process_create(
     archiver: Box<dyn Archive>,
     r: &Receiver<Box<dyn JobInfo>>,
     sigchannel: &Receiver<bool>,
     cleanup: bool,
 ) -> Result<(), Error> {
-    info!("Start processing events");
+    info!("Start processing create events");
 
     #[allow(clippy::zero_ptr, clippy::drop_copy)]
     loop {
         select! {
-            recv(sigchannel) -> b => if let Ok(true) = b  {
+            recv(sigchannel) -> b => if let Ok(true) = b {
                 if !cleanup {
                     info!("Stopped processing entries, {} skipped", r.len());
                 } else {
@@ -113,7 +113,49 @@ pub fn process(
         }
     }
 
-    debug!("Processing loop exited");
+    debug!("Processing creation loop exited");
+    Ok(())
+}
+
+/// The process_remove function consumes job removal events and gets the necessary data from the
+/// scheduler before sending the information to the archive.
+pub fn process_remove(
+    archiver: Box<dyn Archive>,
+    r: &Receiver<Box<dyn JobInfo>>,
+    sigchannel: &Receiver<bool>,
+    cleanup: bool,
+) -> Result<(), Error> {
+    info!("Start processing removal events");
+
+    #[allow(clippy::zero_ptr, clippy::drop_copy)]
+    loop {
+        select! {
+            recv(sigchannel) -> b => if let Ok(true) = b {
+                if !cleanup {
+                        info!("Stopped processing entries, {} skipped", r.len());
+                } else {
+                    info!("Processing {} entries, then stopping", r.len());
+                    for mut entry in r.iter() {
+                        entry.read_job_info()?;
+                        archiver.archive(&entry)?;
+                    }
+                    info!("Done processing");
+                }
+                break;
+            },
+            recv(r) -> entry => {
+                if let Ok(mut job_entry) = entry {
+                    job_entry.job_completion_info()?;
+                    archiver.archive(&job_entry)?;
+                } else {
+                    error!("Error on receiving JobEntry info");
+                    break;
+                }
+            }
+        }
+    }
+
+    debug!("Processing removal loop ended");
     Ok(())
 }
 
@@ -148,7 +190,7 @@ mod tests {
         scope(|s| {
             let path = PathBuf::from(current_dir().unwrap().join("tests/job.123456"));
             let slurm_job_entry = SlurmJobEntry::new(&path, "123456", "mycluster");
-            s.spawn(move |_| match process(archiver, &rx1, &rx2, false) {
+            s.spawn(move |_| match process_create(archiver, &rx1, &rx2, false) {
                 Ok(v) => assert_eq!(v, ()),
                 Err(_) => panic!("Unexpected error from process function"),
             });

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -31,7 +31,7 @@ use std::io::{Error, ErrorKind};
 use std::path::Path;
 
 use super::scheduler::job::JobInfo;
-use super::scheduler::Scheduler;
+use super::scheduler::{Scheduler, SchedulerEvent};
 
 /// The check_and_queue function verifies that the inotify event pertains
 /// and actual Slurm job entry and pushes the correct information to the
@@ -45,7 +45,7 @@ fn check_and_queue(
     debug!("Event received: {:?}", event);
 
     match scheduler.verify_event_kind(&event) {
-        Some(paths) => scheduler
+        Some(SchedulerEvent::Create(paths)) => scheduler
             .create_job_info(&paths[0])
             .ok_or_else(|| {
                 Error::new(

--- a/src/scheduler/job.rs
+++ b/src/scheduler/job.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+Copyright 2019-2023 Andy Georges <itkovian+sarchive@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,9 @@ pub trait JobInfo: Send {
 
     // Return additional information as a set of key-value pairs
     fn extra_info(&self) -> Option<HashMap<String, String>>;
+
+    // Get the job completion info from the scheduler
+    fn job_completion_info(&self) -> Result<(), Error>;
 }
 
 #[cfg(test)]

--- a/src/scheduler/job.rs
+++ b/src/scheduler/job.rs
@@ -50,7 +50,10 @@ pub trait JobInfo: Send {
     fn extra_info(&self) -> Option<HashMap<String, String>>;
 
     // Get the job completion info from the scheduler
-    fn job_completion_info(&self) -> Result<(), Error>;
+    fn job_completion_info(&mut self) -> Result<(), Error>;
+
+    // Return runtime info as a set of key-value pairs
+    fn extra_completion_info(&self) -> Option<HashMap<String, String>>;
 }
 
 #[cfg(test)]

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -46,10 +46,16 @@ pub enum SchedArgs {
     Torque(TorqueArgs),
 }
 
+#[derive(Clone)]
+pub enum SchedulerEvent {
+    Create(Vec<PathBuf>),
+    Remove(Vec<PathBuf>),
+}
+
 pub trait Scheduler: Send + Sync {
     fn watch_locations(&self) -> Vec<PathBuf>;
     fn create_job_info(&self, event_path: &Path) -> Option<Box<dyn JobInfo>>;
-    fn verify_event_kind(&self, event: &Event) -> Option<Vec<PathBuf>>;
+    fn verify_event_kind(&self, event: &Event) -> Option<SchedulerEvent>;
 }
 
 pub fn create(kind: &SchedulerKind, spool_path: &Path, cluster: &str) -> Box<dyn Scheduler> {

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Andy Georges <itkovian+sarchive@gmail.com>
+Copyright 2019-2023 Andy Georges <itkovian+sarchive@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,7 @@ pub enum SchedulerEvent {
 
 pub trait Scheduler: Send + Sync {
     fn watch_locations(&self) -> Vec<PathBuf>;
-    fn create_job_info(&self, event_path: &Path) -> Option<Box<dyn JobInfo>>;
+    fn construct_job_info(&self, event_path: &Path) -> Option<Box<dyn JobInfo>>;
     fn verify_event_kind(&self, event: &Event) -> Option<SchedulerEvent>;
 }
 

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -294,25 +294,19 @@ impl Scheduler for Slurm {
 /// This ignores the path prefix, and checks that
 /// there is a path dir component that starts with "job."
 ///
-///
-/// For example, /var/spool/slurm/hash.3/job.01234./script is a valid path
+/// For example, /var/spool/slurm/hash.3/job.01234 is a valid path
 ///
 /// We return a tuple of two strings: the job ID and the filename, wrapped in
 /// an Option.
 pub fn is_job_path(path: &Path) -> Option<(&str, &str)> {
     // The path is always a directory, by construction (RemoveKind::Folder)
-    debug!("Checking path {:?}", path);
-    let dirname = path.file_name().unwrap().to_str().unwrap();
-
-    debug!("dirname: {dirname}");
-    debug!("extension: {:?}", path.extension().unwrap());
-
+    let dirname = path.file_name()?.to_str()?;
     if dirname.starts_with("job.") {
-        return Some((path.extension().unwrap().to_str().unwrap(), dirname));
-    };
-
-    debug!("{:?} is not a considered job path", &path);
-    None
+        Some((path.extension().unwrap().to_str().unwrap(), dirname))
+    } else {
+        debug!("{:?} is not a considered job path", &path);
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -190,6 +190,8 @@ impl JobInfo for SlurmJobEntry {
         let output = Command::new("/usr/bin/sacct")
             .arg("--job")
             .arg(self.jobid().to_string())
+            .arg("--cluster")
+            .arg(self.cluster().to_string())
             .arg("--parsable2")
             .arg("-o")
             .arg(sacct_fields.join(","))

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -288,25 +288,29 @@ impl Scheduler for Slurm {
     }
 }
 
-/// Verifies that the path metioned in the event is a that of a file that
-/// needs archival
+/// Verifies that the path metioned in the event is a that of a folder that
+/// needs archival.
 ///
-/// This ignores the path prefix, but verifies that
-/// - the path points to a file
-/// - there is a path dir component that starts with "job."
+/// This ignores the path prefix, and checks that
+/// there is a path dir component that starts with "job."
+///
 ///
 /// For example, /var/spool/slurm/hash.3/job.01234./script is a valid path
 ///
 /// We return a tuple of two strings: the job ID and the filename, wrapped in
 /// an Option.
 pub fn is_job_path(path: &Path) -> Option<(&str, &str)> {
-    if path.is_dir() {
-        let dirname = path.file_name().unwrap().to_str().unwrap();
+    // The path is always a directory, by construction (RemoveKind::Folder)
+    debug!("Checking path {:?}", path);
+    let dirname = path.file_name().unwrap().to_str().unwrap();
 
-        if dirname.starts_with("job.") {
-            return Some((path.extension().unwrap().to_str().unwrap(), dirname));
-        };
-    }
+    debug!("dirname: {dirname}");
+    debug!("extension: {:?}", path.extension().unwrap());
+
+    if dirname.starts_with("job.") {
+        return Some((path.extension().unwrap().to_str().unwrap(), dirname));
+    };
+
     debug!("{:?} is not a considered job path", &path);
     None
 }

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -196,11 +196,20 @@ impl JobInfo for SlurmJobEntry {
             .output()?;
 
         if output.status.success() {
-            //String::from_utf8(output.stdout)?.lines();
-            self.info_ = Some(HashMap::default());
+            let job_info = String::from_utf8(output.stdout).unwrap();
+            self.info_ = Some(
+                sacct_fields
+                    .iter()
+                    .map(|s| s.to_string())
+                    .zip(job_info.lines().next().iter().map(|s| s.to_string()))
+                    .collect(),
+            );
             Ok(())
         } else {
-            Ok(())
+            Err(Error::new(
+                std::io::ErrorKind::Other,
+                "Could not get sacct output",
+            ))
         }
     }
 

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -51,7 +51,7 @@ pub struct SlurmJobEntry {
     /// The job's environment in Slurm
     env_: Option<Vec<u8>>,
     /// The job's completion info in Slurm
-    info_: Option<String>,
+    info_: Option<HashMap<String, String>>,
 }
 
 impl SlurmJobEntry {
@@ -174,7 +174,7 @@ impl JobInfo for SlurmJobEntry {
         })
     }
 
-    fn job_completion_info(&self) -> Result<(), Error> {
+    fn job_completion_info(&mut self) -> Result<(), Error> {
         // Get information from the Slurm DBD about the job, using the slurm sacct command
 
         let sacct_fields = vec![
@@ -197,10 +197,15 @@ impl JobInfo for SlurmJobEntry {
 
         if output.status.success() {
             //String::from_utf8(output.stdout)?.lines();
+            self.info_ = Some(HashMap::default());
             Ok(())
         } else {
             Ok(())
         }
+    }
+
+    fn extra_completion_info(&self) -> Option<HashMap<String, String>> {
+        self.info_.clone()
     }
 }
 

--- a/src/scheduler/torque.rs
+++ b/src/scheduler/torque.rs
@@ -29,7 +29,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use super::job::JobInfo;
-use super::Scheduler;
+use super::{Scheduler, SchedulerEvent};
 
 use crate::utils;
 
@@ -209,14 +209,14 @@ impl Scheduler for Torque {
         }
     }
 
-    fn verify_event_kind(&self, event: &Event) -> Option<Vec<PathBuf>> {
+    fn verify_event_kind(&self, event: &Event) -> Option<SchedulerEvent> {
         if let Event {
             kind: EventKind::Create(CreateKind::File),
             paths,
             ..
         } = event
         {
-            Some(paths.to_vec())
+            Some(SchedulerEvent::Create(paths.to_vec()))
         } else {
             None
         }

--- a/src/scheduler/torque.rs
+++ b/src/scheduler/torque.rs
@@ -171,8 +171,12 @@ impl JobInfo for TorqueJobEntry {
         )
     }
 
-    fn job_completion_info(&self) -> Result<(), Error> {
+    fn job_completion_info(&mut self) -> Result<(), Error> {
         Ok(())
+    }
+
+    fn extra_completion_info(&self) -> Option<HashMap<String, String>> {
+        None
     }
 }
 

--- a/src/scheduler/torque.rs
+++ b/src/scheduler/torque.rs
@@ -170,6 +170,10 @@ impl JobInfo for TorqueJobEntry {
                 .collect(),
         )
     }
+
+    fn job_completion_info(&self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 pub struct Torque {
@@ -197,7 +201,7 @@ impl Scheduler for Torque {
         }
     }
 
-    fn create_job_info(&self, event_path: &Path) -> Option<Box<dyn JobInfo>> {
+    fn construct_job_info(&self, event_path: &Path) -> Option<Box<dyn JobInfo>> {
         if let Some((jobid, filename)) = is_job_path(event_path) {
             Some(Box::new(TorqueJobEntry::new(
                 filename,
@@ -209,6 +213,7 @@ impl Scheduler for Torque {
         }
     }
 
+    // TODO: should we also check for deletion here?
     fn verify_event_kind(&self, event: &Event) -> Option<SchedulerEvent> {
         if let Event {
             kind: EventKind::Create(CreateKind::File),


### PR DESCRIPTION
- When a watched spool dir notices a delete event, the job is probably done
- We can then fetch information from the scheduler's accounting infra
- We ship this information to the same archival backend to store it somewhere.

Addresses #134 